### PR TITLE
Fix/delete item on add

### DIFF
--- a/src/app/components/InventoryItem/index.tsx
+++ b/src/app/components/InventoryItem/index.tsx
@@ -67,8 +67,14 @@ export default (props: Props): JSX.Element => {
     );
   };
 
-  const handleAdd = () => {
+  const handleAddToShoppingList = () => {
     dispatch(addShoppingListItem(props.item.title));
+    alert('Added to Shopping List!');
+  };
+
+  const handleAddToShoppingListAndDelete = () => {
+    handleAddToShoppingList();
+    handleDelete();
   };
 
   return (
@@ -99,6 +105,9 @@ export default (props: Props): JSX.Element => {
             <IconButton onClick={handleDelete}>
               <DeleteIcon color="primary" />
             </IconButton>
+            <IconButton onClick={handleAddToShoppingList}>
+              <Add />
+            </IconButton>
           </>
         ) : (
           <span onClick={handleClick}>
@@ -110,7 +119,7 @@ export default (props: Props): JSX.Element => {
           </span>
         )}
         {props.item.checked ? (
-          <IconButton onClick={handleAdd}>
+          <IconButton onClick={handleAddToShoppingListAndDelete}>
             <Add />
           </IconButton>
         ) : (

--- a/src/app/components/ShoppingListItem/index.tsx
+++ b/src/app/components/ShoppingListItem/index.tsx
@@ -55,7 +55,8 @@ export default (props: Props): JSX.Element => {
         ...props.item,
         checked,
       })
-    ) && dispatch(addInventoryItem(props.item.title));
+    );
+    handleChecked();
   };
 
   const handleDelete = () => {
@@ -64,6 +65,11 @@ export default (props: Props): JSX.Element => {
         ...props.item,
       })
     );
+  };
+
+  const handleChecked = () => {
+    props.item.checked === false &&
+      dispatch(addInventoryItem(props.item.title));
   };
 
   return (

--- a/src/app/components/ShoppingListItem/index.tsx
+++ b/src/app/components/ShoppingListItem/index.tsx
@@ -46,6 +46,11 @@ export default (props: Props): JSX.Element => {
     );
   };
 
+  const handleChecked = () => {
+    props.item.checked === false &&
+      dispatch(addInventoryItem(props.item.title));
+  };
+
   const handleCheck = (
     _: React.ChangeEvent<HTMLInputElement>,
     checked: boolean
@@ -65,11 +70,6 @@ export default (props: Props): JSX.Element => {
         ...props.item,
       })
     );
-  };
-
-  const handleChecked = () => {
-    props.item.checked === false &&
-      dispatch(addInventoryItem(props.item.title));
   };
 
   return (


### PR DESCRIPTION
The user could have added the same item from inventory to the shopping list multiple times. To prevent that, upon adding the item to the shopping list the item is deleted from inventory.
Furthermore, on the shopping list item checkbox click the item was added to inventory, however regardless of whether one was checking or unchecking the checkbox, which is unwanted behavior. Fixed that by calling the function only if checked is true.
