### PR TITLE
Component/header recipes list

### DIFF
--- a/src/app/components/Headers/HeaderDefault.tsx
+++ b/src/app/components/Headers/HeaderDefault.tsx
@@ -2,18 +2,20 @@ import { AppBar, IconButton, Typography } from '@mui/material';
 import React from 'react';
 import './index.css';
 import HomeIcon from '@mui/icons-material/Home';
+import { useNavigate } from 'react-router';
 
 type Props = {
   children: string;
 };
 
 export default (props: Props): JSX.Element => {
+  const navigate = useNavigate();
   return (
     <AppBar
       className="header"
       sx={{ display: 'flex', flexDirection: 'row', gap: '17px' }}
     >
-      <IconButton>
+      <IconButton onClick={() => navigate('/')}>
         <HomeIcon fontSize="large" sx={{ alignSelf: 'flex-start' }} />
       </IconButton>
       <Typography

--- a/src/app/components/Headers/HeaderDefault.tsx
+++ b/src/app/components/Headers/HeaderDefault.tsx
@@ -1,6 +1,7 @@
-import { AppBar, Typography } from '@mui/material';
+import { AppBar, IconButton, Typography } from '@mui/material';
 import React from 'react';
 import './index.css';
+import HomeIcon from '@mui/icons-material/Home';
 
 type Props = {
   children: string;
@@ -8,7 +9,13 @@ type Props = {
 
 export default (props: Props): JSX.Element => {
   return (
-    <AppBar className="header">
+    <AppBar
+      className="header"
+      sx={{ display: 'flex', flexDirection: 'row', gap: '17px' }}
+    >
+      <IconButton>
+        <HomeIcon fontSize="large" sx={{ alignSelf: 'flex-start' }} />
+      </IconButton>
       <Typography
         variant="h4"
         sx={{

--- a/src/app/components/Headers/HeaderRecipes.stories.tsx
+++ b/src/app/components/Headers/HeaderRecipes.stories.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import HeaderRecipes from './HeaderRecipes';
+
+export default {
+  title: 'Component/HeaderRecipes',
+  component: HeaderRecipes,
+};
+
+export const HeaderRecipe = (): JSX.Element => <HeaderRecipes />;

--- a/src/app/components/Headers/HeaderRecipes.tsx
+++ b/src/app/components/Headers/HeaderRecipes.tsx
@@ -1,0 +1,15 @@
+import { AppBar, InputBase } from '@mui/material';
+import React from 'react';
+import SearchIcon from '@mui/icons-material/Search';
+
+export default () => {
+  return (
+    <AppBar className="header">
+      <InputBase
+        placeholder="Search…"
+        inputProps={{ 'aria-label': 'search' }}
+      />
+      <SearchIcon />
+    </AppBar>
+  );
+};

--- a/src/app/components/Headers/HeaderRecipes.tsx
+++ b/src/app/components/Headers/HeaderRecipes.tsx
@@ -1,15 +1,28 @@
-import { AppBar, InputBase } from '@mui/material';
+import { AppBar, InputBase, Paper } from '@mui/material';
 import React from 'react';
 import SearchIcon from '@mui/icons-material/Search';
 
 export default () => {
   return (
-    <AppBar className="header">
-      <InputBase
-        placeholder="Search…"
-        inputProps={{ 'aria-label': 'search' }}
-      />
-      <SearchIcon />
+    <AppBar className="header-flex">
+      <Paper
+        sx={{
+          display: 'flex',
+          width: '60%',
+          height: '2.2rem',
+          alignSelf: 'center',
+          verticalAlign: 'center',
+          mt: 1.5,
+          borderRadius: 5,
+        }}
+      >
+        <InputBase
+          sx={{ p: 2 }}
+          placeholder="Search for a recipe.."
+          inputProps={{ 'aria-label': 'search' }}
+        />
+        <SearchIcon sx={{ m: 1 }} />
+      </Paper>
     </AppBar>
   );
 };

--- a/src/app/components/Headers/index.css
+++ b/src/app/components/Headers/index.css
@@ -3,6 +3,12 @@
   margin-bottom: 20px;
 }
 
+.header-flex {
+  display: flex;
+  height: 55px;
+  margin-bottom: 20px;
+}
+
 .image-header {
   display: block;
   margin-top: -8em;

--- a/src/app/pages/Recipes/index.css
+++ b/src/app/pages/Recipes/index.css
@@ -1,3 +1,4 @@
-.bottom-padding {
+.padding {
   padding-bottom: 70px;
+  padding-top: 70px;
 }

--- a/src/app/pages/Recipes/index.tsx
+++ b/src/app/pages/Recipes/index.tsx
@@ -4,12 +4,14 @@ import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import DoneOutlinedIcon from '@mui/icons-material/DoneOutlined';
 import RecipesList from '../../components/RecipesList/RecipesList';
 import './index.css';
+import HeaderRecipes from '../../components/Headers/HeaderRecipes';
 
 export default (): JSX.Element => {
   const [newRecipe, setNewRecipe] = useState<boolean>(false);
   return (
     <>
-      <main className="bottom-padding">
+      <HeaderRecipes />
+      <main className="padding">
         <RecipesList />
       </main>
       <Footer


### PR DESCRIPTION
- updated default header to navigate to the homepage
- created a new type of header with a search bar
- created a story for the recipes header

Recipes Page Header
<img width="323" alt="header recipes" src="https://user-images.githubusercontent.com/90032497/146102189-08668fcf-f71e-4408-8f7f-f08b11b6375b.png">

